### PR TITLE
Make device.bootStart() and device.shutDown() blocking operations so …

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -80,12 +80,10 @@ class Fotoapparat
     fun start() {
         logger.recordMethod()
 
-        executor.execute(Operation {
-            device.bootStart(
-                    orientationSensor = orientationSensor,
-                    mainThreadErrorCallback = mainThreadErrorCallback
-            )
-        })
+        device.bootStart(
+          orientationSensor = orientationSensor,
+          mainThreadErrorCallback = mainThreadErrorCallback
+        )
     }
 
     /**
@@ -97,11 +95,9 @@ class Fotoapparat
         logger.recordMethod()
 
         executor.cancelTasks()
-        executor.execute(Operation {
-            device.shutDown(
-                    orientationSensor = orientationSensor
-            )
-        })
+        device.shutDown(
+          orientationSensor = orientationSensor
+        )
     }
 
     /**


### PR DESCRIPTION
…there is always a guarantee that they will be executed

If activity starts and then immediately stops (startActivityForResult/setResult, finish) then there is a possibility that device.shutDown() won't be executed leading to an activity leak